### PR TITLE
Mitigating the risk of overflows in integer products

### DIFF
--- a/ebf.py
+++ b/ebf.py
@@ -2173,7 +2173,7 @@ def read(filename, path = '/' ,recon=0,ckon=1,begin=0,end=None):
                     print('ebf Warning, begin>end')
                     end1=begin1
                 if begin1 > 0:
-                    fp1.seek(begin1*header.datasize*header.elements()//header.dim[0],1) 
+                    fp1.seek(begin1*int(header.datasize)*int(header.elements())//int(header.dim[0]),1) 
                 if (end1-begin1) != header.dim[0]:
                     header.dim[0]=end1-begin1
                     


### PR DESCRIPTION
Hi Sanjib,

I ran into an issue in some of my use cases using ebfpy where the product I have modified in this commit would overflow in ebfpy original implementation. I identified that this was due to both `header.datasize` and `header.elements()` being numpy typed integers (`int32` for the former and `int64` for the latter). It seems that the native Python integer type is not as likely to overflow with products of large numbers compared to numpy integer types, and this was what was going on here.

For the specific case I ran into, my `begin1` number was `1087168606` while my `header.elements()` returned `1123530259` as `numpy.int64`. With `header.datasize` returning `8` as type `numpy.int32`, the final product ended up returning `-8675009469902759984`, when it should return `9771734603806791632`. The correction I included in my commit below avoid the overflow and make the product return the correct integer.

Note that I also converted the denominator `header.dim[0]` for consistency and because keeping it as `numpy.int64` resulted in the division returning a numpy float number rather than an integer.